### PR TITLE
ReactorKit State Snippets

### DIFF
--- a/reactorkit-state-bind.codesnippet
+++ b/reactorkit-state-bind.codesnippet
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>_rsb</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>reactor.state.map { $0.&lt;#State#&gt; }
+            .bind(to: &lt;#BindTo#&gt;)
+            .disposed(by: self.disposeBag)</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>F47F3F4D-ACB6-4F21-AAF8-D6DBE7B23022</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>Reactor State Binding</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/reactorkit-state-subscribe.codesnippet
+++ b/reactorkit-state-subscribe.codesnippet
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>_rss</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>reactor.state.map { $0.&lt;#State#&gt; }
+            .subscribe(onNext: { [weak self] &lt;#State#&gt; in
+                guard let self = self else { return }
+                &lt;#code#&gt;
+            }).disposed(by: self.disposeBag)</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>4FDA079F-6876-4339-9161-AF6EA52A1787</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>Reactor State Subscribe</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>


### PR DESCRIPTION
ReactorKit을 사용하다 보면 ReactorKit.View에서 
Reactor의 State 값을 사용하게 됩니다.
이럴 때 state의 값을 사용하는 구문들을 반복하게 되는데,
이러한 코드를 snippets로 작성 해 보았습니다. 

```
reactor.state.map { $0.isNextEnable }
            .bind(to: nextMonthButton.rx.isEnabled)
            .disposed(by: self.disposeBag)
        
reactor.state.map { $0.currentDate }
            .subscribe(onNext: { date in
                print("currentDate: \(date)")
            }).disposed(by: self.disposeBag)
```

단축어는 [React Native Snippet Extension](https://marketplace.visualstudio.com/items?itemName=jundat95.react-native-snippet)에서 영감을 얻어,
다음과 같이 지정하였습니다.

reactor-state-bind <_rsb>
reactor-state-subscribe <_rss>
